### PR TITLE
Update ClientConfig Base class

### DIFF
--- a/packages/polywrap-client/polywrap_client/client.py
+++ b/packages/polywrap-client/polywrap_client/client.py
@@ -40,6 +40,8 @@ class PolywrapClient(Client):
     def __init__(self, config: Optional[PolywrapClientConfig] = None):
         # TODO: this is naive solution need to use polywrap-client-config-builder once we have it
         self._config = config or PolywrapClientConfig(
+            envs={},
+            interfaces={},
             resolver=FsUriResolver(file_reader=SimpleFileReader())
         )
 

--- a/packages/polywrap-client/polywrap_client/client.py
+++ b/packages/polywrap-client/polywrap_client/client.py
@@ -61,7 +61,8 @@ class PolywrapClient(Client):
 
     def get_implementations(self, uri: Uri) -> Result[List[Uri]]:
         if interface_implementations := next(
-            filter(lambda x: x == uri, self._config.interfaces[uri]), None
+            filter(lambda x: x == uri,
+             self._config.interfaces), None
         ):
             print(interface_implementations)
             return Ok(interface_implementations)

--- a/packages/polywrap-client/polywrap_client/client.py
+++ b/packages/polywrap-client/polywrap_client/client.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from textwrap import dedent
-from typing import Any, List, Optional, Union, cast
+from typing import Any, List, Optional, Union, cast, Dict
 
 from polywrap_core import (
     Client,
@@ -53,7 +53,7 @@ class PolywrapClient(Client):
     ) -> IUriResolver:
         return self._config.resolver
 
-    def get_envs(self, options: Optional[GetEnvsOptions] = None) -> List[Env]:
+    def get_envs(self, options: Optional[GetEnvsOptions] = None) -> Dict[Uri, List[Uri]]:
         return self._config.envs
 
     def get_interfaces(self) -> List[InterfaceImplementations]:
@@ -61,9 +61,10 @@ class PolywrapClient(Client):
 
     def get_implementations(self, uri: Uri) -> Result[List[Uri]]:
         if interface_implementations := next(
-            filter(lambda x: x.interface == uri, self._config.interfaces), None
+            filter(lambda x: x == uri, self._config.interfaces[uri]), None
         ):
-            return Ok(interface_implementations.implementations)
+            print(interface_implementations)
+            return Ok(interface_implementations)
         else:
             return Err.from_str(f"Unable to find implementations for uri: {uri}")
 

--- a/packages/polywrap-client/tests/test_client.py
+++ b/packages/polywrap-client/tests/test_client.py
@@ -95,7 +95,7 @@ async def test_env():
     options = InvokerOptions(
         uri=uri, method="externalEnvMethod", args={}, encode_result=False
     )
-    print(client._config__)
+    print(client._config)
     result = await client.invoke(options)
 
     assert result.unwrap() == env

--- a/packages/polywrap-client/tests/test_client.py
+++ b/packages/polywrap-client/tests/test_client.py
@@ -5,7 +5,7 @@ from polywrap_core import Uri, InvokerOptions, InterfaceImplementations, Env
 from polywrap_uri_resolvers import BaseUriResolver, SimpleFileReader
 
 from polywrap_client.client import PolywrapClientConfig
-
+import pytest
 
 async def test_invoke():
     client = PolywrapClient()
@@ -41,7 +41,7 @@ async def test_subinvoke():
 
     assert result.unwrap() == "1 + 2 = 3"
 
-
+@pytest.mark.skip(reason="Exception: Unable to find implementations for uri: wrap://ens/interface.eth")
 async def test_interface_implementation():
     uri_resolver = BaseUriResolver(
         file_reader=SimpleFileReader(),
@@ -54,11 +54,10 @@ async def test_interface_implementation():
 
     client = PolywrapClient(
         config=PolywrapClientConfig(
-            envs={},
+            envs={Uri('wrap://ens/interface.eth'): {'environment_variable', 'test'}},
             interfaces={
-                    InterfaceImplementations(
-                        interface=Uri("ens/interface.eth"), implementations=[impl_uri]
-                    )
+                Uri("wrap://ens/interface.eth"):
+                [impl_uri]
                 },
             resolver=uri_resolver,
             )
@@ -75,7 +74,7 @@ async def test_interface_implementation():
 
     assert result.unwrap() == {"str": "hello", "uint8": 2}
 
-
+@pytest.mark.skip(reason="Message: __wrap_abort: Missing required property: 'externalArray: [UInt32]'")
 async def test_env():
     uri_resolver = BaseUriResolver(
         file_reader=SimpleFileReader(),

--- a/packages/polywrap-client/tests/test_client.py
+++ b/packages/polywrap-client/tests/test_client.py
@@ -31,7 +31,7 @@ async def test_subinvoke():
         },
     )
 
-    client = PolywrapClient(config=PolywrapClientConfig(envs=[], resolver=uri_resolver))
+    client = PolywrapClient(config=PolywrapClientConfig(envs={}, interfaces={}, resolver=uri_resolver))
     uri = Uri(
         f'fs/{Path(__file__).parent.joinpath("cases", "simple-subinvoke", "invoke").absolute()}'
     )
@@ -54,14 +54,15 @@ async def test_interface_implementation():
 
     client = PolywrapClient(
         config=PolywrapClientConfig(
-            envs=[],
+            envs={},
+            interfaces={
+                    InterfaceImplementations(
+                        interface=Uri("ens/interface.eth"), implementations=[impl_uri]
+                    )
+                },
             resolver=uri_resolver,
-            interfaces=[
-                InterfaceImplementations(
-                    interface=Uri("ens/interface.eth"), implementations=[impl_uri]
-                )
-            ],
-        )
+            )
+        
     )
     uri = Uri(
         f'fs/{Path(__file__).parent.joinpath("cases", "simple-interface", "wrapper").absolute()}'
@@ -86,13 +87,15 @@ async def test_env():
 
     client = PolywrapClient(
         config=PolywrapClientConfig(
-            envs=[Env(uri=uri, env=env)],
+            envs={uri: env},
             resolver=uri_resolver,
+            interfaces={}
         )
     )
     options = InvokerOptions(
         uri=uri, method="externalEnvMethod", args={}, encode_result=False
     )
+    print(client._config__)
     result = await client.invoke(options)
 
     assert result.unwrap() == env

--- a/packages/polywrap-client/tests/test_client.py
+++ b/packages/polywrap-client/tests/test_client.py
@@ -41,7 +41,7 @@ async def test_subinvoke():
 
     assert result.unwrap() == "1 + 2 = 3"
 
-@pytest.mark.skip(reason="Exception: Unable to find implementations for uri: wrap://ens/interface.eth")
+# @pytest.mark.skip(reason="Exception: Unable to find implementations for uri: wrap://ens/interface.eth")
 async def test_interface_implementation():
     uri_resolver = BaseUriResolver(
         file_reader=SimpleFileReader(),
@@ -74,7 +74,7 @@ async def test_interface_implementation():
 
     assert result.unwrap() == {"str": "hello", "uint8": 2}
 
-@pytest.mark.skip(reason="Message: __wrap_abort: Missing required property: 'externalArray: [UInt32]'")
+# @pytest.mark.skip(reason="Message: __wrap_abort: Missing required property: 'externalArray: [UInt32]'")
 async def test_env():
     uri_resolver = BaseUriResolver(
         file_reader=SimpleFileReader(),

--- a/packages/polywrap-core/polywrap_core/types/client.py
+++ b/packages/polywrap-core/polywrap_core/types/client.py
@@ -17,7 +17,7 @@ from .uri_resolver_handler import UriResolverHandler
 
 @dataclass(slots=True, kw_only=True)
 class ClientConfig:
-    # TODO this is naive solution, the `Any` type should be more specific (str | Uri | int, etc.)
+    # TODO  is this a naive solution? the `Any` type should be more specific (str | Uri | int, etc.)
     envs: Dict[Uri, Env: Dict[str, Any]] = field(default_factory=dict) 
     interfaces: Dict[Uri, List[Uri]]
     resolver: IUriResolver

--- a/packages/polywrap-core/polywrap_core/types/client.py
+++ b/packages/polywrap-core/polywrap_core/types/client.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from dataclasses import dataclass, field
-from typing import List, Optional, Union
+from typing import List, Optional, Union, Dict, Any
 
 from polywrap_manifest import AnyWrapManifest, DeserializeManifestOptions
 from polywrap_result import Result
@@ -17,8 +17,9 @@ from .uri_resolver_handler import UriResolverHandler
 
 @dataclass(slots=True, kw_only=True)
 class ClientConfig:
-    envs: List[Env] = field(default_factory=list)
-    interfaces: List[InterfaceImplementations] = field(default_factory=list)
+    # TODO this is naive solution, the `Any` type should be more specific (str | Uri | int, etc.)
+    envs: Dict[Uri, Env: Dict[str, Any]] = field(default_factory=dict) 
+    interfaces: Dict[Uri, List[Uri]]
     resolver: IUriResolver
 
 

--- a/packages/polywrap-core/polywrap_core/types/client.py
+++ b/packages/polywrap-core/polywrap_core/types/client.py
@@ -18,7 +18,7 @@ from .uri_resolver_handler import UriResolverHandler
 @dataclass(slots=True, kw_only=True)
 class ClientConfig:
     # TODO  is this a naive solution? the `Any` type should be more specific (str | Uri | int, etc.)
-    envs: Dict[Uri, Env: Dict[str, Any]] = field(default_factory=dict) 
+    envs: Dict[Uri, Dict[str, Any]] = field(default_factory=dict) 
     interfaces: Dict[Uri, List[Uri]]
     resolver: IUriResolver
 

--- a/packages/polywrap-wasm/polywrap_wasm/imports.py
+++ b/packages/polywrap-wasm/polywrap_wasm/imports.py
@@ -316,7 +316,7 @@ def create_instance(
             raise WasmAbortError(
                 f"failed calling invoker.get_implementations({repr(Uri(uri))})"
             ) from result.unwrap_err()
-        implementations: List[str] = [uri.uri for uri in result.unwrap()]
+        implementations: List[Uri] = [uri.uri for uri in result.unwrap()]
         state.get_implementations_result = msgpack_encode(implementations)
         return len(implementations) > 0
 


### PR DESCRIPTION
Initially we had a ClientConfig base class with a list of Environments, and a list of interfaces,

```py
@dataclass(slots=True, kw_only=True)
class ClientConfig:
    envs: List[Env] = field(default_factory=list)
    interfaces: List[InterfaceImplementations] = field(default_factory=list)
    resolver: IUriResolver
```

Both of these fields are now being changed to a Dictionary for simpler client configuration.

```py
@dataclass(slots=True, kw_only=True)
class ClientConfig:
    envs: Dict[Uri, Env: Dict[str, Any]] = field(default_factory=dict) 
    interfaces: Dict[Uri, List[Uri]]
    resolver: IUriResolver
```

This changes break some of the client functionality, working on those fixes now